### PR TITLE
fix: input/button props에 HTMLAttributes 타입 확장 추가

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -8,7 +8,7 @@ type ButtonStyle = 'DEFAULT' | 'POSITIVE' | 'NEGATIVE';
 // 버튼 크기 타입
 type ButtonSize = 'sm' | 'md' | 'lg';
 
-interface ButtonProps {
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonStyle; // 'DEFAULT' | 'POSITIVE' | 'NEGATIVE'
   size?: ButtonSize; // 'sm' | 'md' | 'lg'
   disabled?: boolean; // 버튼 비활성화

--- a/src/components/InputField.tsx
+++ b/src/components/InputField.tsx
@@ -2,7 +2,7 @@
 import { Field, Input, Label } from '@headlessui/react';
 import { forwardRef } from 'react';
 
-interface InputProps {
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   type?: string;
   placeholder: string;
   label?: string;


### PR DESCRIPTION
## ⭐️ 작업 내역

<!--- 작업 내역에 대해 간단하게 작성해주세요. -->

- Input/Button 컴포넌트 props에 HTMLAttributes 타입 확장 추가

## 💡 변경 사항

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->

- InputProps → extends React.InputHTMLAttributes<HTMLInputElement> 추가
- ButtonProps → extends React.ButtonHTMLAttributes<HTMLButtonElement> 추가
- 타입 누락으로 발생하던 에러 해결

## 🎱 연관된 이슈 번호

<!-- 내용에 '#'을 입력하시면 github issues에 등록된 이슈에서 선택하실 수 있습니다.  -->

- #113 

## 📢 전달 사항 (선택)

<!-- 공유 사항이나 논의가 필요한 부분이 있다면 적어주세요. -->

- 기존 코드에서 타입이 누락돼 ...rest 전달 시 TS 에러가 발생했는데, HTML 기본 속성을 확장하여 해결했습니다.

## 💬 리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

-
