### PR TITLE
[P6-121] axios 인터셉터 구현 + 토큰 재발급 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@hookform/resolvers": "^5.2.1",
         "@tanstack/react-query": "^5.85.5",
         "@tanstack/react-query-devtools": "^5.85.5",
+        "axios": "^1.11.0",
         "clsx": "^2.1.1",
         "next": "15.4.6",
         "nth-check": "^2.1.1",
@@ -4724,6 +4725,11 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -4748,6 +4754,16 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -4911,7 +4927,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5071,6 +5086,17 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/commander": {
@@ -5372,6 +5398,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -5468,7 +5502,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -5610,7 +5643,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5620,7 +5652,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5664,7 +5695,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -5677,7 +5707,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6373,6 +6402,25 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -6389,11 +6437,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6444,7 +6506,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -6469,7 +6530,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -6563,7 +6623,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6642,7 +6701,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6655,7 +6713,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -6671,7 +6728,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -7715,7 +7771,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7762,7 +7817,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -7771,7 +7825,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -8458,6 +8511,11 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@hookform/resolvers": "^5.2.1",
     "@tanstack/react-query": "^5.85.5",
     "@tanstack/react-query-devtools": "^5.85.5",
+    "axios": "^1.11.0",
     "clsx": "^2.1.1",
     "next": "15.4.6",
     "nth-check": "^2.1.1",

--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -8,6 +8,8 @@ import Button from '@/components/Button';
 import InputField from '@/components/InputField';
 import Link from 'next/link';
 import { LoginRequestSchema, LoginRequest } from '@/types/schema/userSchema';
+import axios from 'axios';
+import apiAuth from '@/utils/axios/apiAuth';
 // 리액트 훅 폼과 zod를 연결해주는 라이브러리
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useUserStore } from '@/stores/userStore';
@@ -36,78 +38,45 @@ const LoginPage = () => {
 
     // 로그인 데이터 전송
     try {
-      const response = await fetch('https://sp-globalnomad-api.vercel.app/16-6/auth/login', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      });
-
-      //
-      const responseData = await response.json();
-
-      // HTTP 상태 코드 체크
-      if (!response.ok) {
-        if (response.status === 400) {
-          throw new Error('이메일 혹은 비밀번호가 일치하지 않습니다.');
-        } else {
-          throw new Error('로그인 실패: 서버 응답 오류입니다.');
-        }
-      }
+      const response = await apiAuth.post('/auth/login', data);
+      const responseData = response.data;
 
       // 성공적으로 로그인 처리
       localStorage.setItem('access_token', responseData.accessToken);
       localStorage.setItem('refresh_token', responseData.refreshToken);
       localStorage.setItem('user', JSON.stringify(responseData.user));
 
-      console.log('저장 후 확인:', {
-        accessTokenStored: localStorage.getItem('access_token'),
-        refreshTokenStored: localStorage.getItem('refresh_token'),
-      });
-
       // 전역 상태에 유저 정보 저장
-      if (response.ok && responseData.user) {
-        setUser(responseData.user);
-        console.log('User state updated:', responseData.user);
-      }
+      setUser(responseData.user);
 
       router.push('/');
-    } catch (err: unknown) {
-      console.error('로그인 중 오류 발생', err);
+    } catch (err) {
+      let errorMessage = `로그인 중 오류 발생: ${err}`;
 
-      if (err instanceof Error) {
-        setError(err.message); // 실제 Error 메시지 표시
+      if (axios.isAxiosError(err)) {
+        if (err.response) {
+          const statusCode = err.response.status;
+
+          if (statusCode === 400) {
+            errorMessage = '이메일 혹은 비밀번호가 일치하지 않습니다.';
+          } else if (statusCode === 500) {
+            errorMessage = '로그인 실패: 서버 응답 오류입니다.';
+          } else {
+            // 400 또는 500이 아닌 다른 에러 코드
+            errorMessage =
+              err.response.data?.message || `로그인 실패: ${statusCode} 에러가 발생했습니다.`;
+          }
+        } else if (err.request) {
+          // 요청은 보내졌으나 응답을 받지 못한 경우 (네트워크 오류)
+          errorMessage = '로그인 실패: 네트워크 연결을 확인해주세요.';
+        }
       } else {
-        setError('알 수 없는 오류가 발생했습니다.');
+        // Axios 에러가 아닌 다른 종류의 에러 처리 (new Error(...))
+        errorMessage = `로그인 중 오류 발생: ${err instanceof Error ? err.message : String(err)}`;
       }
 
+      setError(errorMessage);
       setLoading(false); // 로딩 상태 해제
-    }
-  };
-
-  const refreshAccessToken = async (): Promise<boolean> => {
-    const refreshToken = localStorage.getItem('refresh_token');
-    if (!refreshToken) return false;
-    try {
-      const response = await fetch('/* 토큰 갱신 API 엔드포인트 */', {
-        // 실제 엔드포인트로 대체
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ refreshToken }),
-      });
-      if (!response.ok) {
-        throw new Error('요청 실패');
-      }
-      const data: { accessToken: string } = await response.json();
-      localStorage.setItem('access_token', data.accessToken);
-      return true;
-    } catch (error) {
-      console.error('토큰 갱신 실패:', error); // 오류 로깅 추가
-      localStorage.removeItem('access_token');
-      localStorage.removeItem('refresh_token');
-      localStorage.removeItem('user');
-      return false;
     }
   };
 

--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -31,7 +31,6 @@ const LoginPage = () => {
 
   // 로그인 요청
   const onSubmit: SubmitHandler<LoginRequest> = async data => {
-    console.log('전송 데이터:', data);
     setLoading(true);
     setError(null);
 
@@ -57,17 +56,10 @@ const LoginPage = () => {
       // 성공적으로 로그인 처리
       localStorage.setItem('access_token', responseData.accessToken);
       localStorage.setItem('refresh_token', responseData.refreshToken);
-      localStorage.setItem('user', JSON.stringify(responseData.user));
-
-      console.log('저장 후 확인:', {
-        accessTokenStored: localStorage.getItem('access_token'),
-        refreshTokenStored: localStorage.getItem('refresh_token'),
-      });
 
       // 전역 상태에 유저 정보 저장
       if (response.ok && responseData.user) {
         setUser(responseData.user);
-        console.log('User state updated:', responseData.user);
       }
 
       router.push('/');

--- a/src/app/(global)/mypage/components/MyInfoClient.tsx
+++ b/src/app/(global)/mypage/components/MyInfoClient.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import SectionTitle from '@/components/ui/Section/SectionTitle';
+import MyInfoForm from '@/app/(global)/mypage/components/MyInfoForm';
+import Button from '@/components/Button';
+import axios from 'axios';
+import apiAuth from '@/utils/axios/apiAuth';
+
+const MyInfoClient = () => {
+  const handleUpdateMyInfo = async () => {
+    try {
+      const res = await apiAuth.patch('/users/me', {
+        nickname: 'aaa',
+        profileImageUrl: null,
+        newPassword: '123123123',
+      });
+      const data = res.data;
+      console.log(data);
+      alert('내정보 수정 완료');
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        alert(err);
+      } else {
+        alert('알 수 없는 에러가 발생했습니다.');
+      }
+    }
+  };
+
+  return (
+    <div>
+      <SectionTitle
+        title='내 정보'
+        action={
+          <Button variant='POSITIVE' size='md' onClick={handleUpdateMyInfo}>
+            수정하기
+          </Button>
+        }
+      />
+      <MyInfoForm />
+    </div>
+  );
+};
+export default MyInfoClient;

--- a/src/app/(global)/mypage/components/MyInfoForm.tsx
+++ b/src/app/(global)/mypage/components/MyInfoForm.tsx
@@ -1,11 +1,26 @@
+'use client';
+
 import InputField from '@/components/InputField';
+import { useUserStore } from '@/stores/userStore';
 
 const MyInfoForm = () => {
   const INPUT_CLASS_NAME = 'mb-8 w-full';
+  const user = useUserStore(state => state.user);
+
   return (
     <div>
-      <InputField label='닉네임' placeholder='닉네임' className={INPUT_CLASS_NAME}></InputField>
-      <InputField label='이메일' placeholder='이메일' className={INPUT_CLASS_NAME}></InputField>
+      <InputField
+        label='닉네임'
+        placeholder='닉네임'
+        className={INPUT_CLASS_NAME}
+        value={user?.nickname}
+      ></InputField>
+      <InputField
+        label='이메일'
+        placeholder='이메일'
+        className={INPUT_CLASS_NAME}
+        value={user?.email}
+      ></InputField>
       <InputField
         label='비밀번호'
         placeholder='8자 이상 입력해 주세요'

--- a/src/app/(global)/mypage/page.tsx
+++ b/src/app/(global)/mypage/page.tsx
@@ -1,12 +1,6 @@
-import SectionTitle from '@/components/ui/Section/SectionTitle';
-import MyInfoForm from '@/app/(global)/mypage/components/MyInfoForm';
+import MyInfoClient from './components/MyInfoClient';
 
 const page = () => {
-  return (
-    <div>
-      <SectionTitle title='내 정보' />
-      <MyInfoForm />
-    </div>
-  );
+  return <MyInfoClient />;
 };
 export default page;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -48,10 +48,10 @@ export const PATHS = {
   MAIN: '/',
   ACTIVITY_DETAIL: (id: number) => `/activities/${id}`,
   MYPAGE: '/mypage',
-  MY_ACTIVITIES: `/mypage/my-activities`,
+  MY_ACTIVITIES: '/mypage/my-activities',
   MY_RESERVATIONS: '/mypage/my-reservations',
   RESERVATIONS: '/mypage/reservations',
-  LOGIN: '/login',
+  LOGIN: '/signin',
   SIGNUP: '/signup',
 };
 

--- a/src/utils/axios/apiAuth.ts
+++ b/src/utils/axios/apiAuth.ts
@@ -31,6 +31,7 @@ const apiAuth: AxiosInstance = axios.create({
 apiAuth.interceptors.request.use(
   config => {
     const accessToken = localStorage.getItem('access_token');
+    console.log(accessToken);
     if (accessToken) {
       if (config.headers) {
         config.headers.Authorization = `Bearer ${accessToken}`;
@@ -82,7 +83,7 @@ apiAuth.interceptors.response.use(
         }
 
         // 리프레쉬 토큰 있을 경우, 토큰 재발급
-        const res = await axios.post('/auth/tokens');
+        const res = await apiAuth.post('/auth/tokens');
         const newAccessToken = res.data.accessToken;
         const newRefreshToken = res.data.refreshToken;
 

--- a/src/utils/axios/apiAuth.ts
+++ b/src/utils/axios/apiAuth.ts
@@ -12,9 +12,7 @@ let failedQueue: Array<{
   reject: (reason?: any) => void;
 }> = [];
 
-const router = useRouter();
-
-// 요청 대기열 (race condition 방지)
+// 요청 대기 큐 (race condition 방지)
 const processQueue = (error: AxiosError | null, token: string | null = null) => {
   failedQueue.forEach(prom => {
     if (error) {
@@ -27,100 +25,104 @@ const processQueue = (error: AxiosError | null, token: string | null = null) => 
 };
 
 // API 클라이언트 인스턴스 생성
-const apiAuth: AxiosInstance = axios.create({
+const api: AxiosInstance = axios.create({
   baseURL: `${REQUEST_URL}`,
 });
 
-// 요청 인터셉터: 모든 axios 요청 헤더에 액세스 토큰 추가
-apiAuth.interceptors.request.use(
-  config => {
-    const accessToken = localStorage.getItem('access_token');
+export const apiAuth = () => {
+  const router = useRouter();
 
-    if (accessToken && !config.url?.includes('/auth/tokens')) {
-      // 토큰 재발급 요청에는 액세스 토큰 제외
-      if (config.headers) {
-        config.headers.Authorization = `Bearer ${accessToken}`;
+  // 요청 인터셉터: 모든 axios 요청 헤더에 액세스 토큰 추가
+  api.interceptors.request.use(
+    config => {
+      const accessToken = localStorage.getItem('access_token');
+
+      if (accessToken && !config.url?.includes('/auth/tokens')) {
+        // 토큰 재발급 요청에는 액세스 토큰 제외
+        if (config.headers) {
+          config.headers.Authorization = `Bearer ${accessToken}`;
+        }
       }
-    }
 
-    return config;
-  },
-  (error: AxiosError) => {
-    return Promise.reject(error);
-  },
-);
+      return config;
+    },
+    (error: AxiosError) => {
+      return Promise.reject(error);
+    },
+  );
 
-// 응답 인터셉터
-apiAuth.interceptors.response.use(
-  (response: AxiosResponse) => response,
-  async (error: AxiosError) => {
-    const originalRequest = error.config as AxiosRequestConfig & { _retry?: boolean }; // 실패한 원본 요청 + retry
+  // 응답 인터셉터
+  api.interceptors.response.use(
+    (response: AxiosResponse) => response,
+    async (error: AxiosError) => {
+      const originalRequest = error.config as AxiosRequestConfig & { _retry?: boolean }; // 실패한 원본 요청 + retry
 
-    // 401 에러 시 액세스 토큰 재발급
-    if (error.response?.status === 401 && !originalRequest._retry) {
-      // 이미 토큰 재발급 중이면 재발급 완료까지 대기 (경쟁 조건(race condition) 처리)
-      if (isRefreshing) {
-        return new Promise((resolve, reject) => {
-          failedQueue.push({ resolve, reject });
-        })
-          .then(token => {
-            if (originalRequest.headers) {
-              originalRequest.headers.Authorization = `Bearer ${token}`;
-            }
-            return apiAuth(originalRequest);
+      // 401 에러 시 액세스 토큰 재발급
+      if (error.response?.status === 401 && !originalRequest._retry) {
+        // 이미 토큰 재발급 중이면 재발급 완료까지 대기 (경쟁 조건(race condition) 처리)
+        if (isRefreshing) {
+          return new Promise((resolve, reject) => {
+            failedQueue.push({ resolve, reject });
           })
-          .catch(err => {
-            return Promise.reject(err);
+            .then(token => {
+              if (originalRequest.headers) {
+                originalRequest.headers.Authorization = `Bearer ${token}`;
+              }
+              return api(originalRequest);
+            })
+            .catch(err => {
+              return Promise.reject(err);
+            });
+        }
+
+        originalRequest._retry = true;
+        isRefreshing = true;
+
+        // 토큰 재발급
+        try {
+          const refreshToken = localStorage.getItem('refresh_token');
+
+          // 리프레쉬 토큰 없을 경우, 로그인 페이지로 리다이렉트
+          if (!refreshToken) {
+            localStorage.clear();
+            router.replace(ROUTES.LOGIN);
+            return Promise.reject(new Error('로그인이 필요합니다.'));
+          }
+
+          // 리프레쉬 토큰 있을 경우, 토큰 재발급
+          const res = await axios.post(`${REQUEST_URL}/auth/tokens`, null, {
+            headers: { Authorization: `Bearer ${refreshToken}` },
           });
-      }
+          const newAccessToken = res.data.accessToken;
+          const newRefreshToken = res.data.refreshToken;
 
-      originalRequest._retry = true;
-      isRefreshing = true;
+          localStorage.setItem('access_token', newAccessToken);
+          localStorage.setItem('refresh_token', newRefreshToken);
 
-      // 토큰 재발급
-      try {
-        const refreshToken = localStorage.getItem('refresh_token');
+          // 대기열에 있던 요청들을 새로운 토큰으로 재시도
+          processQueue(null, newAccessToken);
 
-        // 리프레쉬 토큰 없을 경우, 로그인 페이지로 리다이렉트
-        if (!refreshToken) {
+          // 원래 요청을 새로운 토큰으로 재시도
+          if (originalRequest.headers) {
+            originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+          }
+
+          return api(originalRequest);
+        } catch (refreshError) {
+          // 재발급 실패 시, 대기 요청들 실패 처리 후 로그인 페이지로 리다이렉트
+          processQueue(refreshError as AxiosError, null);
           localStorage.clear();
           router.replace(ROUTES.LOGIN);
-          return Promise.reject(new Error('로그인이 필요합니다.'));
+
+          return Promise.reject(refreshError);
+        } finally {
+          isRefreshing = false;
         }
-
-        // 리프레쉬 토큰 있을 경우, 토큰 재발급
-        const res = await axios.post(`${REQUEST_URL}/auth/tokens`, null, {
-          headers: { Authorization: `Bearer ${refreshToken}` },
-        });
-        const newAccessToken = res.data.accessToken;
-        const newRefreshToken = res.data.refreshToken;
-
-        localStorage.setItem('access_token', newAccessToken);
-        localStorage.setItem('refresh_token', newRefreshToken);
-
-        // 대기열에 있던 요청들을 새로운 토큰으로 재시도
-        processQueue(null, newAccessToken);
-
-        // 원래 요청을 새로운 토큰으로 재시도
-        if (originalRequest.headers) {
-          originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
-        }
-
-        return apiAuth(originalRequest);
-      } catch (refreshError) {
-        // 재발급 실패 시, 대기 요청들 실패 처리 후 로그인 페이지로 리다이렉트
-        processQueue(refreshError as AxiosError, null);
-        localStorage.clear();
-        router.replace(ROUTES.LOGIN);
-
-        return Promise.reject(refreshError);
-      } finally {
-        isRefreshing = false;
       }
-    }
 
-    return Promise.reject(error);
-  },
-);
+      return Promise.reject(error);
+    },
+  );
+};
 
 export default apiAuth;

--- a/src/utils/axios/apiAuth.ts
+++ b/src/utils/axios/apiAuth.ts
@@ -1,14 +1,18 @@
 'use client';
 
 import axios, { AxiosInstance, AxiosResponse, AxiosError, AxiosRequestConfig } from 'axios';
+import { useRouter } from 'next/navigation';
 import { REQUEST_URL } from '../api-public';
 import { ROUTES } from '@/constants';
 
-let isRefreshing = false;
+let isRefreshing = false; // 토큰 재발급 진행중 여부
+
 let failedQueue: Array<{
   resolve: (value: unknown) => void;
   reject: (reason?: any) => void;
 }> = [];
+
+const router = useRouter();
 
 // 요청 대기열 (race condition 방지)
 const processQueue = (error: AxiosError | null, token: string | null = null) => {
@@ -80,7 +84,7 @@ apiAuth.interceptors.response.use(
         // 리프레쉬 토큰 없을 경우, 로그인 페이지로 리다이렉트
         if (!refreshToken) {
           localStorage.clear();
-          window.location.href = ROUTES.LOGIN;
+          router.replace(ROUTES.LOGIN);
           return Promise.reject(new Error('로그인이 필요합니다.'));
         }
 
@@ -107,7 +111,7 @@ apiAuth.interceptors.response.use(
         // 재발급 실패 시, 대기 요청들 실패 처리 후 로그인 페이지로 리다이렉트
         processQueue(refreshError as AxiosError, null);
         localStorage.clear();
-        window.location.href = ROUTES.LOGIN;
+        router.replace(ROUTES.LOGIN);
 
         return Promise.reject(refreshError);
       } finally {

--- a/src/utils/axios/apiAuth.ts
+++ b/src/utils/axios/apiAuth.ts
@@ -31,12 +31,14 @@ const apiAuth: AxiosInstance = axios.create({
 apiAuth.interceptors.request.use(
   config => {
     const accessToken = localStorage.getItem('access_token');
-    console.log(accessToken);
-    if (accessToken) {
+
+    if (accessToken && !config.url?.includes('/auth/tokens')) {
+      // 토큰 재발급 요청에는 액세스 토큰 제외
       if (config.headers) {
         config.headers.Authorization = `Bearer ${accessToken}`;
       }
     }
+
     return config;
   },
   (error: AxiosError) => {
@@ -83,7 +85,9 @@ apiAuth.interceptors.response.use(
         }
 
         // 리프레쉬 토큰 있을 경우, 토큰 재발급
-        const res = await apiAuth.post('/auth/tokens');
+        const res = await axios.post(`${REQUEST_URL}/auth/tokens`, null, {
+          headers: { Authorization: `Bearer ${refreshToken}` },
+        });
         const newAccessToken = res.data.accessToken;
         const newRefreshToken = res.data.refreshToken;
 

--- a/src/utils/axios/apiAuth.ts
+++ b/src/utils/axios/apiAuth.ts
@@ -1,0 +1,117 @@
+'use client';
+
+import axios, { AxiosInstance, AxiosResponse, AxiosError, AxiosRequestConfig } from 'axios';
+import { REQUEST_URL } from '../api-public';
+import { ROUTES } from '@/constants';
+
+let isRefreshing = false;
+let failedQueue: Array<{
+  resolve: (value: unknown) => void;
+  reject: (reason?: any) => void;
+}> = [];
+
+// 요청 대기열 (race condition 방지)
+const processQueue = (error: AxiosError | null, token: string | null = null) => {
+  failedQueue.forEach(prom => {
+    if (error) {
+      prom.reject(error);
+    } else {
+      prom.resolve(token);
+    }
+  });
+  failedQueue = [];
+};
+
+// API 클라이언트 인스턴스 생성
+const authApi: AxiosInstance = axios.create({
+  baseURL: `${REQUEST_URL}`,
+});
+
+// 요청 인터셉터: 모든 axios 요청 헤더에 액세스 토큰 추가
+authApi.interceptors.request.use(
+  config => {
+    const accessToken = localStorage.getItem('access_token');
+    if (accessToken) {
+      if (config.headers) {
+        config.headers.Authorization = `Bearer ${accessToken}`;
+      }
+    }
+    return config;
+  },
+  (error: AxiosError) => {
+    return Promise.reject(error);
+  },
+);
+
+// 응답 인터셉터
+authApi.interceptors.response.use(
+  (response: AxiosResponse) => response,
+  async (error: AxiosError) => {
+    const originalRequest = error.config as AxiosRequestConfig & { _retry?: boolean }; // 실패한 원본 요청 + retry
+
+    // 401 에러 시 토큰 재발급
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      // 이미 토큰 재발급 중이면 재발급이 완료될 때까지 대기 (경쟁 조건(race condition) 처리)
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        })
+          .then(token => {
+            if (originalRequest.headers) {
+              originalRequest.headers.Authorization = `Bearer ${token}`;
+            }
+            return authApi(originalRequest);
+          })
+          .catch(err => {
+            return Promise.reject(err);
+          });
+      }
+
+      originalRequest._retry = true;
+      isRefreshing = true;
+
+      // 액세스 토큰 재발급
+      try {
+        const refreshToken = localStorage.getItem('refresh_token');
+
+        // 리프레쉬 토큰 없을 경우, 로그인 요구
+        if (!refreshToken) {
+          localStorage.clear();
+          window.location.href = ROUTES.LOGIN;
+          return Promise.reject(new Error('리프레쉬 토큰이 없습니다. 로그인이 필요합니다.'));
+        }
+
+        // 액세스 토큰 재발급
+        const res = await axios.post('/auth/tokens');
+        const newAccessToken = res.data.accessToken;
+        const newRefreshToken = res.data.refreshToken;
+
+        localStorage.setItem('access_token', newAccessToken);
+        localStorage.setItem('refresh_token', newRefreshToken);
+
+        // 대기열에 있던 요청들을 새로운 토큰으로 재시도
+        processQueue(null, newAccessToken);
+
+        // 원래 요청을 새로운 토큰으로 재시도
+        if (originalRequest.headers) {
+          originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        }
+
+        return authApi(originalRequest);
+      } catch (refreshError) {
+        // 재발급 실패 시, 대기 요청들 실패 처리 후 로그인 페이지로 리다이렉트
+        processQueue(refreshError as AxiosError, null);
+        localStorage.clear();
+        window.location.href = ROUTES.LOGIN;
+
+        return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
+      }
+    }
+
+    return Promise.reject(error);
+  },
+);
+
+export default authApi;

--- a/src/utils/axios/apiAuth.ts
+++ b/src/utils/axios/apiAuth.ts
@@ -23,12 +23,12 @@ const processQueue = (error: AxiosError | null, token: string | null = null) => 
 };
 
 // API 클라이언트 인스턴스 생성
-const authApi: AxiosInstance = axios.create({
+const apiAuth: AxiosInstance = axios.create({
   baseURL: `${REQUEST_URL}`,
 });
 
 // 요청 인터셉터: 모든 axios 요청 헤더에 액세스 토큰 추가
-authApi.interceptors.request.use(
+apiAuth.interceptors.request.use(
   config => {
     const accessToken = localStorage.getItem('access_token');
     if (accessToken) {
@@ -44,7 +44,7 @@ authApi.interceptors.request.use(
 );
 
 // 응답 인터셉터
-authApi.interceptors.response.use(
+apiAuth.interceptors.response.use(
   (response: AxiosResponse) => response,
   async (error: AxiosError) => {
     const originalRequest = error.config as AxiosRequestConfig & { _retry?: boolean }; // 실패한 원본 요청 + retry
@@ -60,7 +60,7 @@ authApi.interceptors.response.use(
             if (originalRequest.headers) {
               originalRequest.headers.Authorization = `Bearer ${token}`;
             }
-            return authApi(originalRequest);
+            return apiAuth(originalRequest);
           })
           .catch(err => {
             return Promise.reject(err);
@@ -97,7 +97,7 @@ authApi.interceptors.response.use(
           originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
         }
 
-        return authApi(originalRequest);
+        return apiAuth(originalRequest);
       } catch (refreshError) {
         // 재발급 실패 시, 대기 요청들 실패 처리 후 로그인 페이지로 리다이렉트
         processQueue(refreshError as AxiosError, null);
@@ -114,4 +114,4 @@ authApi.interceptors.response.use(
   },
 );
 
-export default authApi;
+export default apiAuth;

--- a/src/utils/axios/apiAuth.ts
+++ b/src/utils/axios/apiAuth.ts
@@ -49,9 +49,9 @@ apiAuth.interceptors.response.use(
   async (error: AxiosError) => {
     const originalRequest = error.config as AxiosRequestConfig & { _retry?: boolean }; // 실패한 원본 요청 + retry
 
-    // 401 에러 시 토큰 재발급
+    // 401 에러 시 액세스 토큰 재발급
     if (error.response?.status === 401 && !originalRequest._retry) {
-      // 이미 토큰 재발급 중이면 재발급이 완료될 때까지 대기 (경쟁 조건(race condition) 처리)
+      // 이미 토큰 재발급 중이면 재발급 완료까지 대기 (경쟁 조건(race condition) 처리)
       if (isRefreshing) {
         return new Promise((resolve, reject) => {
           failedQueue.push({ resolve, reject });
@@ -70,18 +70,18 @@ apiAuth.interceptors.response.use(
       originalRequest._retry = true;
       isRefreshing = true;
 
-      // 액세스 토큰 재발급
+      // 토큰 재발급
       try {
         const refreshToken = localStorage.getItem('refresh_token');
 
-        // 리프레쉬 토큰 없을 경우, 로그인 요구
+        // 리프레쉬 토큰 없을 경우, 로그인 페이지로 리다이렉트
         if (!refreshToken) {
           localStorage.clear();
           window.location.href = ROUTES.LOGIN;
-          return Promise.reject(new Error('리프레쉬 토큰이 없습니다. 로그인이 필요합니다.'));
+          return Promise.reject(new Error('로그인이 필요합니다.'));
         }
 
-        // 액세스 토큰 재발급
+        // 리프레쉬 토큰 있을 경우, 토큰 재발급
         const res = await axios.post('/auth/tokens');
         const newAccessToken = res.data.accessToken;
         const newRefreshToken = res.data.refreshToken;


### PR DESCRIPTION
## ⭐️ 작업 내역

<!--- 작업 내역에 대해 간단하게 작성해주세요. -->

> #### 요청 유형별 fetch vs axios vs apiAuth
> 1. 토큰이 필요 없는 '**서버** 컴포넌트'에서의 요청: **`fetch()`**
> 2. 토큰이 필요 없는 '**클라이언트** 컴포넌트'에서의 요청: **`axios()`** 
> 3. **토큰이 필요한 요청** (무조건 클라이언트): **`apiAuth()`** (axios 인스턴스 + 인터셉터)

---

- axios 인스턴스 `apiAuth` 생성
  - teamId 포함된 baseUrl 인스턴스 생성
  - 401 에러 처리용 인터셉터 포함
  - 사용 목적: 권한이 필요한 클라이언트 요청 
- '내 정보 수정' patch 요청에 apiAuth 적용
  - 요청 body는 추후 수정 필요 (인터셉터 테스트용 임시 작성) 

## 💡 변경 사항

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->

- 로그인 페이지에서 로그인 성공 시 user 객체는 로컬스토리지에 저장되지 않도록 수정했습니다. (zustand 스토어와 중복 저장 이슈)
- '내 정보' 페이지 자체는 서버 컴포넌트로 유지하고, `MyInfoClient` 컴포넌트를 따로 만들어서 여기서 내 정보 수정이 이루어지도록 구조를 변경했습니다.
- axios 패키지가 package.json에 없어서 추가 설치했습니다. (병합 후 `npm i` 필요)

## 🎱 연관된 이슈 번호

<!-- 내용에 '#'을 입력하시면 github issues에 등록된 이슈에서 선택하실 수 있습니다.  -->

- #152 

## 📢 전달 사항 (선택)

<!-- 공유 사항이나 논의가 필요한 부분이 있다면 적어주세요. -->

-

## 💬 리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

-
