### PR TITLE
[P6-144] fetch 기반 토큰 재발급 함수 생성 (fetchClientData)

### DIFF
--- a/src/utils/api-client/fetchClientData.ts
+++ b/src/utils/api-client/fetchClientData.ts
@@ -44,7 +44,7 @@ const refreshAccessToken = async () => {
 };
 
 // fetch 래퍼 함수 (외부에서 이 함수 사용)
-export const fetchData = async (endpoint: string, options: RequestInit = {}) => {
+const fetchClientData = async (endpoint: string, options: RequestInit = {}) => {
   let accessToken = localStorage.getItem('access_token');
   const headers = new Headers(options.headers);
 
@@ -115,3 +115,5 @@ const processQueue = (error: Error | null, token: string | null = null) => {
   });
   failedQueue = [];
 };
+
+export default fetchClientData;

--- a/src/utils/api-client/fetchData.ts
+++ b/src/utils/api-client/fetchData.ts
@@ -1,0 +1,116 @@
+import { REQUEST_URL } from '@/utils/api-public';
+import { ROUTES } from '@/constants';
+
+let isRefreshing = false;
+let failedQueue: Array<{
+  resolve: (value: unknown) => void;
+  reject: (reason?: any) => void;
+}> = [];
+
+// 토큰 재발급 함수
+const refreshAccessToken = async () => {
+  try {
+    const refreshToken = localStorage.getItem('refresh_token');
+    if (!refreshToken) {
+      // 리프레시 토큰이 없으면 로그인 페이지로 이동
+      localStorage.clear();
+      window.location.href = ROUTES.LOGIN;
+      return Promise.reject('로그인이 필요합니다.');
+    }
+
+    const response = await fetch(`${REQUEST_URL}/auth/tokens`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${refreshToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to refresh token');
+    }
+
+    const data = await response.json();
+    const newAccessToken = data.accessToken;
+    const newRefreshToken = data.refreshToken;
+    localStorage.setItem('access_token', newAccessToken);
+    localStorage.setItem('refresh_token', newRefreshToken);
+
+    return newAccessToken;
+  } catch (error) {
+    throw error;
+  }
+};
+
+// fetch 래퍼 함수 (이 함수로 요청)
+export const fetchData = async (endpoint: string, options: RequestInit = {}) => {
+  let accessToken = localStorage.getItem('access_token');
+  const headers = new Headers(options.headers);
+
+  // 요청 헤더에 액세스 토큰 추가
+  if (accessToken && !endpoint.includes('/auth/tokens')) {
+    headers.set('Authorization', `Bearer ${accessToken}`);
+  }
+
+  try {
+    const response = await fetch(`${REQUEST_URL}${endpoint}`, {
+      ...options,
+      headers,
+    });
+
+    if (response.status === 401) {
+      // 401 에러 시 토큰 재발급
+      if (isRefreshing) {
+        // 이미 재발급 중이면 대기
+        const token = await new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        });
+        headers.set('Authorization', `Bearer ${token}`);
+        const retryResponse = await fetch(`${REQUEST_URL}${endpoint}`, { ...options, headers });
+        return await retryResponse.json();
+      }
+
+      isRefreshing = true;
+      try {
+        const newAccessToken = await refreshAccessToken();
+        processQueue(null, newAccessToken);
+        headers.set('Authorization', `Bearer ${newAccessToken}`);
+        const retryResponse = await fetch(`${REQUEST_URL}${endpoint}`, { ...options, headers });
+        return await retryResponse.json();
+      } catch (err) {
+        processQueue(err as Error, null);
+        throw err;
+      } finally {
+        isRefreshing = false;
+      }
+    }
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(errorData.message || 'API 호출 실패');
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error('API 호출 중 에러 발생:', error);
+    throw error;
+  }
+};
+
+/**
+ * 실패 요청 대기열 처리 함수
+ * - 여러 개의 요청이 동시에 토큰 만료 에러(401)를 받았을 때, 토큰 재발급 요청을 한 번만 보내고 나머지 요청들은 그 결과를 기다렸다가 처리하게 함
+ * - 비효율적인 중복 재발급 요청(race condition) 방지
+ * @param error 토큰 재발급 에러
+ * @param token 토큰 재발급 성공 시 받아온 액세스 토큰
+ */
+const processQueue = (error: Error | null, token: string | null = null) => {
+  failedQueue.forEach(prom => {
+    if (error) {
+      prom.reject(error);
+    } else {
+      prom.resolve(token); // 실패한 요청들을 새 토큰으로 재시도
+    }
+  });
+  failedQueue = [];
+};

--- a/src/utils/api-client/fetchData.ts
+++ b/src/utils/api-client/fetchData.ts
@@ -18,6 +18,7 @@ const refreshAccessToken = async () => {
       return Promise.reject('로그인이 필요합니다.');
     }
 
+    // 토큰 재발급 요청
     const response = await fetch(`${REQUEST_URL}/auth/tokens`, {
       method: 'POST',
       headers: {
@@ -42,7 +43,7 @@ const refreshAccessToken = async () => {
   }
 };
 
-// fetch 래퍼 함수 (이 함수로 요청)
+// fetch 래퍼 함수 (외부에서 이 함수 사용)
 export const fetchData = async (endpoint: string, options: RequestInit = {}) => {
   let accessToken = localStorage.getItem('access_token');
   const headers = new Headers(options.headers);


### PR DESCRIPTION
## ⭐️ 작업 내역

<!--- 작업 내역에 대해 간단하게 작성해주세요. -->

- fetch 기반 토큰 재발급 함수 생성 (`fetchClientData`)

## 💡 변경 사항

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->

- 

## 🎱 연관된 이슈 번호

<!-- 내용에 '#'을 입력하시면 github issues에 등록된 이슈에서 선택하실 수 있습니다.  -->

- #183 

## 📢 전달 사항 (선택)

<!-- 공유 사항이나 논의가 필요한 부분이 있다면 적어주세요. -->

### `fetchClientData()` 사용법
- GET, DELETE 요청은 인자로 endpoint만 전달 / POST, PATCH 요청은 인자로 endpoint와 body 전달
- fetch options는 각 요청 메서드에 맞게 직접 입력하도록 제작했습니다. 
- 액세스 토큰 만료 후 요청을 보내면 자동으로 새 액세스 토큰이 발급되어 인증이 유지됩니다. (물론 fetchClientData로 요청 보내야함)
```
import { fetchClientData} from '@/utils/api-client/fetchClientData';

// GET 요청
const getMyActivityData = async (endpoint: string) => {
  const data = await fetchClientData(endpoint, { method: 'GET' });
  console.log(data);
};

// POST 요청
const createMyActivity = async (endpoint: string, body: any) => {
  const data = await fetchClientData(endpoint, {
    method: 'POST',
    body: JSON.stringify(body),
    headers: {
      'Content-Type': 'application/json',
    },
  });
  console.log(data);
};

// DELETE 요청
const deleteMyActivity = async (endpoint: string) => {
  const data = await fetchClientData(endpoint, { method: 'DELETE' });
  console.log(data);
};

// PATCH 요청
const updateMyActivity = async (endpoint: string, body: any) => {
  const data = await fetchClientData(endpoint, {
    method: 'PATCH',
    body: JSON.stringify(body),
    headers: {
      'Content-Type': 'application/json',
    },
  });
  console.log(data);
};
```

#### 추가 내용
- 액세스 토큰은 30분, 리프레쉬 토큰은 2주 후 만료

## 💬 리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- 토큰을 담는 fetch니까 함수명을 fetchAuthData로 하려다가.. auth(로그인/회원가입) 기능에만 한정된 함수처럼 보여서 그냥 fetchData라고 지었는데 괜찮은가요? 애매하다 싶으시면 다른 함수명도 추천받습니다!
- axios 패키지, apiAuth 함수는 일단 리뷰어분들 체크 받고 PR 병합 직전에 제거하려고 합니당
